### PR TITLE
Remove unneeded gnuplot dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   - path: CMakeLists.txt  # [win]
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
@@ -31,7 +31,6 @@ requirements:
     - libtiff
     - zlib
     - ghostscript  # [unix]
-    - gnuplot  # [unix]
     - libwebp  # [unix]
     - libxml2  # [unix]
     - zstd  # [unix]
@@ -50,7 +49,6 @@ requirements:
     - libtiff
     - zlib
     - ghostscript  # [unix]
-    - gnuplot  # [unix]
     - libwebp  # [unix]
     - libxml2  # [unix]
     - zstd  # [unix]


### PR DESCRIPTION
The graphicsmagick conda-forge package depends on gnuplot, which in turn depends on a python interpreter.

AFAICS graphicsmagick doesn't depend / no-longer depends on gnuplot.

What I've found is that https://wiki.octave.org/GraphicsMagick lists gnuplot as an optional dependency that

    ... and most users will have no need for them.

In the source code of GrpahicsMagick 1.3.45 I can still see that gnuplot is part of configure.ac, but these lines are commented out.

Therefore, let's remove the gnuplot dependency from the package.

Fixes: #37

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
